### PR TITLE
chore: Reword few sentences on the Try/Catch EIP

### DIFF
--- a/try-catch-eip/src/App.test.tsx
+++ b/try-catch-eip/src/App.test.tsx
@@ -1,11 +1,11 @@
-import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import {App} from './App';
 import {DoCatch} from "./DoCatch";
 import * as React from "react";
 
 test('renders try and finally blocks with explanation', () => {
   render(<App/>);
-  let description = screen.getByText(/First we have a block of steps to run./i);
+  let description = screen.getByText(/First, we have a block of steps to run./i);
   expect(description).toBeInTheDocument();
   description = screen.getByText(/The do-finally block is always executed at the end./i);
   expect(description).toBeInTheDocument();

--- a/try-catch-eip/src/DoCatch.tsx
+++ b/try-catch-eip/src/DoCatch.tsx
@@ -65,16 +65,13 @@ export const DoCatch = ({ updateStep, step }: IDoCatchForm) => {
   const [catchClauses, setCatchClauses] = useState(branches);
 
   const saveHandler = () => {
-    const branches = [];
-    const i = 0;
-
     if (step.branches == null) {
       step.branches = [];
     }
 
     let tryclause = step.branches
       .filter((o: null) => o != null)
-      .filter((b: { identifier: string }) => b.identifier == 'steps');
+      .filter((b: { identifier: string }) => b.identifier === 'steps');
     if (tryclause.length > 0) {
       tryclause = tryclause[0];
     } else {
@@ -89,7 +86,7 @@ export const DoCatch = ({ updateStep, step }: IDoCatchForm) => {
 
     let finallyclause = step.branches
       .filter((o: null) => o != null)
-      .filter((b: { identifier: string }) => b.identifier == 'do-finally');
+      .filter((b: { identifier: string }) => b.identifier === 'do-finally');
     if (finallyclause.length > 0) {
       finallyclause = finallyclause[0];
     } else {
@@ -124,7 +121,7 @@ export const DoCatch = ({ updateStep, step }: IDoCatchForm) => {
 
   return (
     <div className={'do-try pf-u-py-lg'}>
-      <p>This EIP behaves like a try-catch-finally blocks in Java.</p>
+      <p>This EIP behaves like a try-catch-finally block in Java.</p>
       <p>You can define the steps of each block in the canvas. To add new catch blocks, use this tab.</p>
         <Button variant='link' icon={<PlusCircleIcon />} className={'new-do-catch'} data-testid='trycatch-add-catch-button' onClick={addNewCatch}>
           New Catch Block

--- a/try-catch-eip/src/DynamicInputs.tsx
+++ b/try-catch-eip/src/DynamicInputs.tsx
@@ -96,9 +96,9 @@ export const DynamicInputs = ({
             <div className='do-try-catch-eip-catch-clause'>
                 <form>
                     <div style={style}>
-                        <p>First we have a block of steps to run. </p>
+                        <p>First, we have a block of steps to run. </p>
                         <p>If an exception is raised on this block,
-                            it may be catch by one of the following
+                            it may be caught by one of the following
                             blocks.</p>
                     </div>
                     {Object.entries(catchClauses).map(([idx, value]) => {
@@ -179,7 +179,7 @@ export const DynamicInputs = ({
                     })}
                     <div style={style}>
                         <p>The do-finally block is always executed at the
-                            end, whether or not an exception was catch.</p>
+                            end, whether or not an exception was caught.</p>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
## Purpose
* Reword a couple of sentences from the `Try/Catch` EIP
* Remove unused variables
* Enforce type equality with `===`

### What is the step(s) that this extension covers?
`Try/Catch/Finally`
