### PR TITLE
chore: Add Load Balance folder to Dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,12 @@ updates:
     open-pull-requests-limit: 5
     
   - package-ecosystem: "npm" 
+    directory: "/load-balance"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 5
+    
+  - package-ecosystem: "npm" 
     directory: "/set-body" 
     schedule:
       interval: "daily"


### PR DESCRIPTION
fixes #260

Thanks for contributing!

## Purpose
_Describe the problem or feature in addition to a link to the issues._

**Is this a new step extension or an improvement for an existing one?**

### What is the step(s) that this extension covers?

### Open Questions and Pre-Merge TODOs

Please ensure your pull request adheres to the following guidelines:

- [ ] There are tests that cover at least 75% of the step extension code
- [ ] All tests pass with `yarn test`
- [ ] There commands `yarn clean`, `yarn install`, `yarn test`, and `yarn build` finish without errors
- [ ] The file `/.github/dependabot.yml` contains an entry for this extension
- [ ] The extension contains a `yarn.lock` file
- [ ] Improvements of existing step extensions should be backwards compatible unless specified otherwise.
- [ ] There is a corresponding view definition in the catalog https://github.com/KaotoIO/kaoto-viewdefinition-catalog
