### PR TITLE
fix(http): Provide only required node modules as polyfills.

### DIFF
--- a/http/webpack.common.js
+++ b/http/webpack.common.js
@@ -92,7 +92,9 @@ module.exports = () => {
           },
         },
       }),
-      new NodePolyfillPlugin(),
+      new NodePolyfillPlugin({
+        includeAliases: ['https', 'process', 'Buffer'],
+      }),
       new DefinePlugin({
         browser: true,
       }),


### PR DESCRIPTION
### Context
Currently, we're providing almost a complete node environment in the browser by using [NodePolyfillPlugin](https://github.com/Richienb/node-polyfill-webpack-plugin).

Although is not clear why, it seems that this is colliding inside of KaotoUI, particularly the assert module. Notice that this happens only when the application is served as a ModuleFederation, so running it as a standalone behaves well.

### Changes
The fix consists in only providing the required dependencies into the target library: [@apidevtools/swagger-parser](https://github.com/APIDevTools/swagger-parser)

related issue: https://github.com/APIDevTools/swagger-parser/issues/137

fixes: https://github.com/KaotoIO/kaoto-ui/issues/1416
