### PR TITLE
[Choice] fix: If index was 0, it didn't do anything

### DIFF
--- a/choice/src/Components/ChoiceStep.tsx
+++ b/choice/src/Components/ChoiceStep.tsx
@@ -48,7 +48,7 @@ export const ChoiceStep = (props: any) => {
 
   function handleDeleteBranch(branch: BranchProps) {
     const index = step.branches?.indexOf(branch);
-    if (step.branches && index && index !== -1) {
+    if (step.branches && index != undefined && index !== -1) {
       const newBranches = step.branches.filter((_b, i) => i !== index);
       step.branches = newBranches;
       const isOtherwise = branch.identifier === 'otherwise';


### PR DESCRIPTION
Thanks for contributing!

## Purpose

This is a fix for https://github.com/KaotoIO/step-extension-repository/issues/162

### What is the step(s) that this extension covers?

`choice` in Camel DSL.

### Open Questions and Pre-Merge TODOs

Please ensure your pull request adheres to the following guidelines:

- [x] There are tests that cover at least 75% of the step extension code
- [x] All tests pass with `yarn test`
- [x] There commands `yarn clean`, `yarn install`, `yarn test`, and `yarn build` finish without errors
- [x] The file `/.github/dependabot.yml` contains an entry for this extension
- [x] The extension contains a `yarn.lock` file
- [x] Improvements of existing step extensions should be backwards compatible unless specified otherwise.
- [x] There is a corresponding view definition in the catalog https://github.com/KaotoIO/kaoto-viewdefinition-catalog
