### PR TITLE
fix: Suggest user to configure `expression` object in source code editor

### DIFF
--- a/choice/src/Components/Branch.tsx
+++ b/choice/src/Components/Branch.tsx
@@ -10,6 +10,7 @@ export type BranchProps = {
   isConditioned: boolean
   setCondition: (syntax: string, condition: string) => void;
   onDelete: () => void;
+  hasExpressionObject: boolean;
 }
 
 export const Branch = (props: BranchProps) => {
@@ -41,6 +42,7 @@ export const Branch = (props: BranchProps) => {
             initSyntax={props.conditionSyntax || 'SIMPLE'}
             initExpression={props.condition || ''}
             setPredicate={handleCondition}
+            hasExpressionObject={props.hasExpressionObject}
           />
         )}
       </GridItem>

--- a/choice/src/Components/ChoiceStep.tsx
+++ b/choice/src/Components/ChoiceStep.tsx
@@ -16,6 +16,7 @@ import {useState} from 'react';
 type BranchProps = {
   condition: string | null,
   conditionSyntax: string,
+  expression?: any,
   identifier: string,
   parameters: any[],
   steps: any[]
@@ -117,6 +118,7 @@ export const ChoiceStep = (props: any) => {
               title={title}
               setCondition={(syntax, condition) => setCondition(branch, condition, syntax)}
               onDelete={() => handleDeleteBranch(branch)}
+              hasExpressionObject={branch.expression != null}
             />
           </CardBody>
         </Card>

--- a/choice/src/Components/ExpressionObjectLabel.tsx
+++ b/choice/src/Components/ExpressionObjectLabel.tsx
@@ -1,0 +1,26 @@
+import {Button, FormGroup, Popover} from '@patternfly/react-core';
+import {HelpIcon} from '@patternfly/react-icons';
+
+export const ExpressionObjectLabel = () => {
+  const headerContent = 'Please use the source code editor to configure this property.';
+  const bodyContent = 'Expression';
+  return (
+    <FormGroup
+      className="pf-u-disabled-color-100 pf-u-background-color-200"
+      label="Expression"
+      labelIcon={
+        <Popover headerContent={headerContent} bodyContent={bodyContent}>
+          <Button
+            variant="plain"
+            type="button"
+            aria-label="More info for field"
+            aria-describedby="form-group-label-info"
+            className="pf-c-form__group-label-help"
+          >
+            <HelpIcon/>
+          </Button>
+        </Popover>
+      }>
+    </FormGroup>
+  );
+};

--- a/choice/src/Components/Predicate.tsx
+++ b/choice/src/Components/Predicate.tsx
@@ -1,11 +1,13 @@
 import {FormGroup, FormSelect, FormSelectOption, TextInput} from "@patternfly/react-core";
 import {useState} from "react";
+import {ExpressionObjectLabel} from "./ExpressionObjectLabel";
 
 export type PredicateProps = {
     initSyntax: string,
     initExpression: string,
     identifier: string,
-    setPredicate: (syntax: string, expression: string) => void
+    setPredicate: (syntax: string, expression: string) => void,
+    hasExpressionObject: boolean
 }
 export const Predicate = (props: PredicateProps) => {
 
@@ -24,6 +26,9 @@ export const Predicate = (props: PredicateProps) => {
 
     return (
     <FormGroup>
+        {props.hasExpressionObject &&
+          <ExpressionObjectLabel/>
+        }
         <FormGroup label="Condition Syntax">
             <FormSelect
               data-testid={props.identifier + '-predicate-syntax-select'}

--- a/set-body/src/Components/Expression.tsx
+++ b/set-body/src/Components/Expression.tsx
@@ -1,10 +1,12 @@
 import {FormGroup, FormSelect, FormSelectOption, TextInput} from "@patternfly/react-core";
 import {useState} from "react";
+import {ExpressionObjectLabel} from "./ExpressionObjectLabel";
 
 export type ExpressionSelectProps = {
     initSyntax: string,
     initExpression: string,
     setExpression: (syntax: string, expression: string) => void
+    hasExpressionObject: boolean;
 }
 export const Expression = (props: ExpressionSelectProps) => {
 
@@ -23,6 +25,9 @@ export const Expression = (props: ExpressionSelectProps) => {
 
     return (
     <FormGroup>
+        {props.hasExpressionObject &&
+          <ExpressionObjectLabel/>
+        }
         <FormGroup label="Expression Syntax">
             <FormSelect
               data-testid='expression-syntax-select'

--- a/set-body/src/Components/ExpressionObjectLabel.tsx
+++ b/set-body/src/Components/ExpressionObjectLabel.tsx
@@ -1,0 +1,26 @@
+import {Button, FormGroup, Popover} from '@patternfly/react-core';
+import {HelpIcon} from '@patternfly/react-icons';
+
+export const ExpressionObjectLabel = () => {
+  const headerContent = 'Please use the source code editor to configure this property.';
+  const bodyContent = 'Expression';
+  return (
+    <FormGroup
+      className="pf-u-disabled-color-100 pf-u-background-color-200"
+      label="Expression"
+      labelIcon={
+        <Popover headerContent={headerContent} bodyContent={bodyContent}>
+          <Button
+            variant="plain"
+            type="button"
+            aria-label="More info for field"
+            aria-describedby="form-group-label-info"
+            className="pf-c-form__group-label-help"
+          >
+            <HelpIcon/>
+          </Button>
+        </Popover>
+      }>
+    </FormGroup>
+  );
+};

--- a/set-body/src/Components/SetBodyStep.tsx
+++ b/set-body/src/Components/SetBodyStep.tsx
@@ -22,7 +22,6 @@ export const SetBodyStep = (props: any) => {
     initExpression = props.stepParams?.simple || '';
   }
 
-
   const [stepParams, setStepParams] = useState<SetBodyStepParams>({
         constant: props.stepParams?.constant,
         simple: props.stepParams?.simple,
@@ -50,6 +49,7 @@ export const SetBodyStep = (props: any) => {
             const jq = syntax === 'jq' ? expression : undefined;
             updateStepParams(constant, simple, jq);
           }}
+          hasExpressionObject={props?.stepParams?.expression != null}
         />
 
       <ActionGroup>

--- a/set-header/src/Components/Expression.tsx
+++ b/set-header/src/Components/Expression.tsx
@@ -1,10 +1,12 @@
 import {FormGroup, FormSelect, FormSelectOption, TextInput} from "@patternfly/react-core";
 import {useState} from "react";
+import {ExpressionObjectLabel} from "./ExpressionObjectLabel";
 
 export type ExpressionSelectProps = {
     initSyntax: string,
     initExpression: string,
-    setExpression: (syntax: string, expression: string) => void
+    setExpression: (syntax: string, expression: string) => void,
+    hasExpressionObject: boolean
 }
 export const Expression = (props: ExpressionSelectProps) => {
 
@@ -23,6 +25,9 @@ export const Expression = (props: ExpressionSelectProps) => {
 
     return (
     <FormGroup>
+        {props.hasExpressionObject &&
+          <ExpressionObjectLabel/>
+        }
         <FormGroup label="Expression Syntax">
             <FormSelect
               data-testid='expression-syntax-select'

--- a/set-header/src/Components/ExpressionObjectLabel.tsx
+++ b/set-header/src/Components/ExpressionObjectLabel.tsx
@@ -1,0 +1,26 @@
+import {Button, FormGroup, Popover} from '@patternfly/react-core';
+import {HelpIcon} from '@patternfly/react-icons';
+
+export const ExpressionObjectLabel = () => {
+  const headerContent = 'Please use the source code editor to configure this property.';
+  const bodyContent = 'Expression';
+  return (
+    <FormGroup
+      className="pf-u-disabled-color-100 pf-u-background-color-200"
+      label="Expression"
+      labelIcon={
+        <Popover headerContent={headerContent} bodyContent={bodyContent}>
+          <Button
+            variant="plain"
+            type="button"
+            aria-label="More info for field"
+            aria-describedby="form-group-label-info"
+            className="pf-c-form__group-label-help"
+          >
+            <HelpIcon/>
+          </Button>
+        </Popover>
+      }>
+    </FormGroup>
+  );
+};

--- a/set-header/src/Components/SetHeaderStep.tsx
+++ b/set-header/src/Components/SetHeaderStep.tsx
@@ -67,6 +67,7 @@ export const SetHeaderStep = (props: any) => {
           const jq = syntax === 'jq' ? expression : undefined;
           updateStepParams(constant, simple, jq);
         }}
+        hasExpressionObject={props?.stepParams?.expression != null}
       />
 
       <ActionGroup>

--- a/set-property/src/Components/Expression.tsx
+++ b/set-property/src/Components/Expression.tsx
@@ -1,10 +1,12 @@
 import {FormGroup, FormSelect, FormSelectOption, TextInput} from "@patternfly/react-core";
 import {useState} from "react";
+import {ExpressionObjectLabel} from "./ExpressionObjectLabel";
 
 export type ExpressionSelectProps = {
     initSyntax: string,
     initExpression: string,
-    setExpression: (syntax: string, expression: string) => void
+    setExpression: (syntax: string, expression: string) => void,
+    hasExpressionObject: boolean
 }
 export const Expression = (props: ExpressionSelectProps) => {
 
@@ -23,6 +25,9 @@ export const Expression = (props: ExpressionSelectProps) => {
 
     return (
     <FormGroup>
+        {props.hasExpressionObject &&
+          <ExpressionObjectLabel/>
+        }
         <FormGroup label="Expression Syntax">
             <FormSelect
               data-testid='expression-syntax-select'

--- a/set-property/src/Components/ExpressionObjectLabel.tsx
+++ b/set-property/src/Components/ExpressionObjectLabel.tsx
@@ -1,0 +1,26 @@
+import {Button, FormGroup, Popover} from '@patternfly/react-core';
+import {HelpIcon} from '@patternfly/react-icons';
+
+export const ExpressionObjectLabel = () => {
+  const headerContent = 'Please use the source code editor to configure this property.';
+  const bodyContent = 'Expression';
+  return (
+    <FormGroup
+      className="pf-u-disabled-color-100 pf-u-background-color-200"
+      label="Expression"
+      labelIcon={
+        <Popover headerContent={headerContent} bodyContent={bodyContent}>
+          <Button
+            variant="plain"
+            type="button"
+            aria-label="More info for field"
+            aria-describedby="form-group-label-info"
+            className="pf-c-form__group-label-help"
+          >
+            <HelpIcon/>
+          </Button>
+        </Popover>
+      }>
+    </FormGroup>
+  );
+};

--- a/set-property/src/Components/SetPropertyStep.tsx
+++ b/set-property/src/Components/SetPropertyStep.tsx
@@ -67,6 +67,7 @@ export const SetPropertyStep = (props: any) => {
           const jq = syntax === 'jq' ? expression : undefined;
           updateStepParams(constant, simple, jq);
         }}
+        hasExpressionObject={props?.stepParams?.expression != null}
       />
 
       <ActionGroup>

--- a/transform/src/Components/Expression.tsx
+++ b/transform/src/Components/Expression.tsx
@@ -1,10 +1,12 @@
 import {FormGroup, FormSelect, FormSelectOption, TextInput} from "@patternfly/react-core";
 import {useState} from "react";
+import {ExpressionObjectLabel} from "./ExpressionObjectLabel";
 
 export type ExpressionSelectProps = {
     initSyntax: string,
     initExpression: string,
     setExpression: (syntax: string, expression: string) => void
+    hasExpressionObject: boolean
 }
 export const Expression = (props: ExpressionSelectProps) => {
 
@@ -23,6 +25,9 @@ export const Expression = (props: ExpressionSelectProps) => {
 
     return (
     <FormGroup>
+        {props.hasExpressionObject &&
+          <ExpressionObjectLabel/>
+        }
         <FormGroup label="Expression Syntax">
             <FormSelect
               data-testid='expression-syntax-select'

--- a/transform/src/Components/ExpressionObjectLabel.tsx
+++ b/transform/src/Components/ExpressionObjectLabel.tsx
@@ -1,0 +1,26 @@
+import {Button, FormGroup, Popover} from '@patternfly/react-core';
+import {HelpIcon} from '@patternfly/react-icons';
+
+export const ExpressionObjectLabel = () => {
+  const headerContent = 'Please use the source code editor to configure this property.';
+  const bodyContent = 'Expression';
+  return (
+    <FormGroup
+      className="pf-u-disabled-color-100 pf-u-background-color-200"
+      label="Expression"
+      labelIcon={
+        <Popover headerContent={headerContent} bodyContent={bodyContent}>
+          <Button
+            variant="plain"
+            type="button"
+            aria-label="More info for field"
+            aria-describedby="form-group-label-info"
+            className="pf-c-form__group-label-help"
+          >
+            <HelpIcon/>
+          </Button>
+        </Popover>
+      }>
+    </FormGroup>
+  );
+};

--- a/transform/src/Components/TransformStep.tsx
+++ b/transform/src/Components/TransformStep.tsx
@@ -34,7 +34,7 @@ export const TransformStep = (props: any) => {
   }
 
   return (
-    <Form data-testid='hoge'>
+    <Form>
         <Expression
           initSyntax={initSyntax}
           initExpression={initExpression}
@@ -43,6 +43,7 @@ export const TransformStep = (props: any) => {
             const jq = syntax === 'jq' ? expression : undefined;
             updateStepParams(simple, jq);
           }}
+          hasExpressionObject={props?.stepParams?.expression != null}
         />
 
       <ActionGroup>

--- a/try-catch-eip/src/DynamicInputs.tsx
+++ b/try-catch-eip/src/DynamicInputs.tsx
@@ -41,6 +41,11 @@ export const DynamicInputs = ({
     return onwhen?.representerProperties?.jq ? 'JQ' : 'SIMPLE';
   }
 
+  const extractHasExpressionObject = (idx: string) => {
+    const onwhen = catchClauses[parseInt(idx)]['onwhen'];
+    return onwhen?.representerProperties?.expression != null;
+  }
+
   const handleOnWhen = (syntax: string, expression: string, idx: string) => {
     if (!expression || expression.trim().length == 0) {
       return;
@@ -173,6 +178,7 @@ export const DynamicInputs = ({
                                     initExpression={extractCondition(idx)}
                                     initSyntax={extractConditionSyntax(idx)}
                                     setPredicate={(syntax, expression) => handleOnWhen(syntax, expression, idx)}
+                                    hasExpressionObject={extractHasExpressionObject(idx)}
                                 />
                             </div>
                         );

--- a/try-catch-eip/src/ExpressionObjectLabel.tsx
+++ b/try-catch-eip/src/ExpressionObjectLabel.tsx
@@ -1,0 +1,26 @@
+import {Button, FormGroup, Popover} from '@patternfly/react-core';
+import {HelpIcon} from '@patternfly/react-icons';
+
+export const ExpressionObjectLabel = () => {
+  const headerContent = 'Please use the source code editor to configure this property.';
+  const bodyContent = 'Expression';
+  return (
+    <FormGroup
+      className="pf-u-disabled-color-100 pf-u-background-color-200"
+      label="Expression"
+      labelIcon={
+        <Popover headerContent={headerContent} bodyContent={bodyContent}>
+          <Button
+            variant="plain"
+            type="button"
+            aria-label="More info for field"
+            aria-describedby="form-group-label-info"
+            className="pf-c-form__group-label-help"
+          >
+            <HelpIcon/>
+          </Button>
+        </Popover>
+      }>
+    </FormGroup>
+  );
+};

--- a/try-catch-eip/src/Predicate.tsx
+++ b/try-catch-eip/src/Predicate.tsx
@@ -1,11 +1,13 @@
 import {FormGroup, FormSelect, FormSelectOption, TextInput} from '@patternfly/react-core';
 import {useState} from 'react';
+import {ExpressionObjectLabel} from "./ExpressionObjectLabel";
 
 export type PredicateProps = {
     initSyntax: string,
     initExpression: string,
     identifier: string,
-    setPredicate: (syntax: string, expression: string) => void
+    setPredicate: (syntax: string, expression: string) => void,
+    hasExpressionObject: boolean
 }
 export const Predicate = (props: PredicateProps) => {
 
@@ -24,6 +26,9 @@ export const Predicate = (props: PredicateProps) => {
 
     return (
     <FormGroup>
+        {props.hasExpressionObject &&
+          <ExpressionObjectLabel/>
+        }
         <FormGroup label='Condition Syntax'>
             <FormSelect
               data-testid={props.identifier + '-predicate-syntax-select'}


### PR DESCRIPTION
Fixes: #405

## Purpose
Suggest user to configure `expression` object in source code editor

**Is this a new step extension or an improvement for an existing one?**
existing

### What is the step(s) that this extension covers?
- choice
- set-body
- set-header
- set-property
- transform
- do-try

### Open Questions and Pre-Merge TODOs

Please ensure your pull request adheres to the following guidelines:

- [x] There are tests that cover at least 75% of the step extension code
- [x] All tests pass with `yarn test`
- [x] There commands `yarn clean`, `yarn install`, `yarn test`, and `yarn build` finish without errors
- [x] The file `/.github/dependabot.yml` contains an entry for this extension
- [x] The extension contains a `yarn.lock` file
- [x] Improvements of existing step extensions should be backwards compatible unless specified otherwise.
- [x] There is a corresponding view definition in the catalog https://github.com/KaotoIO/kaoto-viewdefinition-catalog
