### PR TITLE
chore(dependabot): Instruct dependabot to create a single pr

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,59 +6,9 @@ updates:
     schedule:
       interval: "daily"
 
-    
-  # Extensions to watch
-  # create a new element per extension
-  - package-ecosystem: "npm" 
-    directory: "/choice" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/http" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/load-balance"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/set-body" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/set-header" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/set-property" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/step-extension-ogcapi-features-action" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/transform" 
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 5
-    
-  - package-ecosystem: "npm" 
-    directory: "/try-catch-eip" 
+  # Root yarn workspace
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 5


### PR DESCRIPTION
## Purpose
At the moment, every time that `dependabot` creates a pull request to update a dependency, it creates a separate pull request for each sub-package. As an example, to update `webpack`, it will create at least seven pull requests, one for each package.

Checking this issue https://github.com/dependabot/dependabot-core/issues/3399 it seems possible to configure only the root `package.json` and let `dependabot` read the subsequent packages from yarn workspaces.
