### PR TITLE
[REST DSL] fix: Fix handling of endpoints. 

### DIFF
--- a/rest-dsl/src/Components/RestStep.test.tsx
+++ b/rest-dsl/src/Components/RestStep.test.tsx
@@ -1,22 +1,76 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import RestStep from "./RestStep";
 import { exampleStep } from "./test/step-example";
+import { IStepProps, IStepPropsBranch } from 'kaoto/types/dts/src/types';
 
 test('Loads new endpoints', async () => {
-  render(<RestStep
-    fetchStepDetails={(stepId: string) => Promise.resolve({
-      name: 'step-unknown',
-      id: stepId,
-      type: 'MIDDLE',
-      branches: []
-    })}
-    updateStep={(p: any) => console.log(p)}
-    step={{
-      name: 'rest',
-      type: 'START',
-      branches: []
-    }}
-  />);
+  const updateStep = (step: IStepProps) => {
+    expect(step.branches?.length).toBe(2);
+    let restBranch: IStepPropsBranch | undefined = step.branches?.pop();
+    expect(restBranch).not.toBeNull();
+
+    //POST
+    let consume: IStepProps | undefined = restBranch?.steps?.pop();
+    expect(consume).not.toBeNull();
+    expect(consume?.id).toEqual("camel-rest-verb-post");
+    expect(consume?.branches).not.toBeNull();
+    expect(consume?.branches).not.toBeUndefined();
+    expect(consume?.branches?.length).toBe(1);
+    let endpoints : IStepProps[] | undefined = consume?.branches?.pop()?.steps;
+    expect(endpoints).not.toBeUndefined();
+    expect(endpoints).not.toBeNull();
+    expect(endpoints?.length).toBe(2);
+    expect(endpoints?.pop()?.id).toEqual("direct-producer");
+    expect(endpoints?.pop()?.id).toEqual("CAMEL-REST-CONSUMES");
+
+    //GET
+    restBranch = step.branches?.pop();
+    consume = restBranch?.steps?.pop();
+    expect(consume?.id).toEqual("camel-rest-verb-get");
+    expect(consume).not.toBeNull();
+    expect(consume?.branches).not.toBeNull();
+    expect(consume?.branches).not.toBeUndefined();
+    expect(consume?.branches?.length).toBe(8);
+    endpoints = consume?.branches?.pop()?.steps;
+    expect(endpoints).not.toBeUndefined();
+    expect(endpoints).not.toBeNull();
+    expect(endpoints?.length).toBe(2);
+    expect(endpoints?.pop()?.id).toEqual("direct-producer");
+    expect(endpoints?.pop()?.id).toEqual("CAMEL-REST-CONSUMES");
+
+  };
+  const fetchStepDetails = (stepId: string) => Promise.resolve({
+    name: 'step-unknown',
+    id: stepId,
+    type: 'MIDDLE',
+    branches: []
+  });
+
+  render(<RestStep fetchStepDetails={fetchStepDetails} updateStep={updateStep} step={{
+    "name": "rest",
+    "type": "START",
+    "id": "CAMEL-REST-DSL",
+    "kind": "CAMEL-REST-DSL",
+    "title": "REST DSL",
+    "description": "This step represents a REST API.",
+    "group": "REST DSL",
+    "parameters": [
+      {
+        "type": "string",
+        "id": "path",
+        "title": "Path of the endpoint",
+        "description": "Path where this endpoint is listening."
+      },
+      {
+        "type": "string",
+        "id": "description",
+        "title": "Description of the endpoint",
+        "description": "Human readable description of this endpoint."
+      }
+    ],
+    "required": [],
+    "branches": []
+  }} />);
 
   const specUrlInput = screen.getByTestId('spec-url-input');
   expect(specUrlInput).toBeInTheDocument();
@@ -31,98 +85,109 @@ test('Loads new endpoints', async () => {
 
   await waitFor(() => {
     expect(screen.getByTestId('endpoint-block-0/feed/daily-chuck')).toBeInTheDocument();
+  }, { timeout: 5000 }).then(async () => {
+
+    expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-1/feed/daily-chuck.json')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.json')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-2/feed/daily-chuck.xml')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.xml')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-3/feed/daily-chuck/stats')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck/stats')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-4/jokes/categories')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/categories')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-6/jokes/search')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/search')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-7/jokes/slack')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/slack')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-8/jokes/{id}')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/{id}')).toBeInTheDocument();
+
+    const newEndpointPath = screen.getByTestId('new-endpoint-path');
+    expect(newEndpointPath).toBeDefined();
+    fireEvent.change(newEndpointPath, { target: { value: '/ola/ke/ase' } });
+
+    const newEndpointName = screen.getByTestId('new-endpoint-name');
+    expect(newEndpointName).toBeDefined();
+    fireEvent.change(newEndpointName, { target: { value: 'pakekieresabeesojajajasaludos' } });
+
+    const addNewEndpoint = screen.getByTestId('new-endpoint-button');
+    expect(addNewEndpoint).toBeInTheDocument();
+    fireEvent.click(addNewEndpoint);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('endpoint-block-0pakekieresabeesojajajasaludos')).toBeInTheDocument();
+    }).then(async () => {
+
+      expect(screen.getByTestId('endpoint-remove-pakekieresabeesojajajasaludos')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-0/feed/daily-chuck')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-1/feed/daily-chuck.json')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.json')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-2/feed/daily-chuck.xml')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.xml')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-3/feed/daily-chuck/stats')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck/stats')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-4/jokes/categories')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/jokes/categories')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-6/jokes/search')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/jokes/search')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-7/jokes/slack')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/jokes/slack')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-block-8/jokes/{id}')).toBeInTheDocument();
+      expect(screen.getByTestId('endpoint-remove-/jokes/{id}')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('endpoint-remove-/feed/daily-chuck'));
+
+      await waitFor(() => { expect(screen.queryByTestId('endpoint-remove-/feed/daily-chuck')).not.toBeInTheDocument() });
+
+      const generateEndpoints = screen.getByTestId('rest-add-endpoints');
+      expect(generateEndpoints).toBeInTheDocument();
+      fireEvent.click(generateEndpoints);
+
+      await new Promise<void>((resolve, _) => { setTimeout(resolve, 0); });
+
+    });
   });
-
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-1/feed/daily-chuck.json')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.json')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-2/feed/daily-chuck.xml')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.xml')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-3/feed/daily-chuck/stats')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck/stats')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-4/jokes/categories')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/categories')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-6/jokes/search')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/search')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-7/jokes/slack')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/slack')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-8/jokes/{id}')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/{id}')).toBeInTheDocument();
-
-  const newEndpointPath = screen.getByTestId('new-endpoint-path');
-  expect(newEndpointPath).toBeDefined();
-  fireEvent.change(newEndpointPath, { target: { value: '/ola/ke/ase' } });
-
-  const newEndpointName = screen.getByTestId('new-endpoint-name');
-  expect(newEndpointName).toBeDefined();
-  fireEvent.change(newEndpointName, { target: { value: 'pakekieresabeesojajajasaludos' } });
-
-  const newEndpointVerb = screen.getByTestId('new-endpoint-verb');
-  expect(newEndpointVerb).toBeDefined();
-  fireEvent.change(newEndpointVerb, { target: { value: 'POST' } });
-
-  const addNewEndpoint = screen.getByTestId('new-endpoint-button');
-  expect(addNewEndpoint).toBeInTheDocument();
-  fireEvent.click(addNewEndpoint);
-
-  await waitFor(() => {
-    expect(screen.getByTestId('endpoint-block-0pakekieresabeesojajajasaludos')).toBeInTheDocument();
-  });
-  
-  expect(screen.getByTestId('endpoint-remove-pakekieresabeesojajajasaludos')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-0/feed/daily-chuck')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-1/feed/daily-chuck.json')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.json')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-2/feed/daily-chuck.xml')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck.xml')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-3/feed/daily-chuck/stats')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/feed/daily-chuck/stats')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-4/jokes/categories')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/categories')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-6/jokes/search')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/search')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-5/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/random')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-7/jokes/slack')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/slack')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-8/jokes/{id}')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/{id}')).toBeInTheDocument();
-
 });
 
 test('Loads existing endpoints', async () => {
+
+  const fetchStepDetails = (stepId: string) => Promise.resolve({
+    name: 'step-unknown',
+    id: stepId,
+    type: 'MIDDLE',
+    branches: []
+  });
+
   render(<RestStep
-    fetchStepDetails={(stepId: string) => Promise.resolve({
-      name: 'step-unknown',
-      id: stepId,
-      type: 'MIDDLE',
-      branches: []
-    })}
-    updateStep={(p: any) => console.log(p)}
+    fetchStepDetails={fetchStepDetails}
+    updateStep={(_: IStepProps) => console.log("Nothing to do here.")}
     step={exampleStep}
   />);
-
 
   const newEndpointsList = screen.getByTestId('rest-existing-endpoints');
   expect(newEndpointsList).toBeInTheDocument();
 
   await waitFor(() => {
     expect(screen.getByTestId('endpoint-block-0/jokes/search')).toBeInTheDocument();
+  }).then(() => {
+    expect(screen.getByTestId('endpoint-remove-/jokes/search')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-block-1/jokes/slack')).toBeInTheDocument();
+    expect(screen.getByTestId('endpoint-remove-/jokes/slack')).toBeInTheDocument();
+
+
+    const generateEndpoints = screen.getByTestId('rest-add-endpoints');
+    expect(generateEndpoints).toBeInTheDocument();
+    fireEvent.click(generateEndpoints);
   });
-  expect(screen.getByTestId('endpoint-remove-/jokes/search')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-block-1/jokes/slack')).toBeInTheDocument();
-  expect(screen.getByTestId('endpoint-remove-/jokes/slack')).toBeInTheDocument();
-
-
-  const generateEndpoints = screen.getByTestId('rest-add-endpoints');
-  expect(generateEndpoints).toBeInTheDocument();
-  fireEvent.click(generateEndpoints);
 
 });

--- a/rest-dsl/src/Components/RestStep.tsx
+++ b/rest-dsl/src/Components/RestStep.tsx
@@ -51,11 +51,11 @@ async function parseApiSpec(
           Object.entries(path).forEach((method: [string, OpenAPI.Operation]) => {
             operations.set(method[0], method[1]);
           });
-          let produces: Map<string, string[]> = new Map<string, string[]>();
-          let consumes: Map<string, string[]> = new Map<string, string[]>();
-          let produce: Map<string, string> = new Map<string, string>();
-          let consume: Map<string, string> = new Map<string, string>();
           operations.forEach((op: OpenAPI.Operation, verb: string) => {
+            let produces: Map<string, string[]> = new Map<string, string[]>();
+            let consumes: Map<string, string[]> = new Map<string, string[]>();
+            let produce: Map<string, string> = new Map<string, string>();
+            let consume: Map<string, string> = new Map<string, string>();
             const producesMediaType: string[] = [];
             if ('produces' in op) {
               op.produces?.forEach((prod: string) => producesMediaType.push(prod));


### PR DESCRIPTION

## Purpose
Offer only one endpoint per verb and path.

Added more tests to check the generation is done right.

### What is the step(s) that this extension covers?

REST DSL

- [x] There are tests that cover at least 75% of the step extension code
- [x] All tests pass with `yarn test`
- [x] There commands `yarn clean`, `yarn install`, `yarn test`, and `yarn build` finish without errors
- [x] Improvements of existing step extensions should be backwards compatible unless specified otherwise.
- [x] There is a corresponding view definition in the catalog https://github.com/KaotoIO/kaoto-viewdefinition-catalog
