### PR TITLE
Exclude common workspace from creating dist

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 yarn install --immutable
 yarn workspaces foreach --exclude "@kaoto/step-extension-repository" --parallel --verbose run clean
-yarn workspaces foreach --exclude "@kaoto/step-extension-repository" --parallel --verbose run build
+yarn workspaces foreach --exclude "@kaoto/step-extension-repository" --topological-dev --parallel --verbose run build
 
 rm -rf ./dist
 mkdir -p ./dist
 
-yarn workspaces foreach --exclude "@kaoto/step-extension-repository" --parallel --verbose exec bash -c 'working_folder=${PWD##*/}; cp -r "${PWD}/dist/" "../dist/${working_folder}"'
+yarn workspaces foreach --exclude "@kaoto/step-extension-repository" --exclude common --parallel --verbose exec bash -c 'working_folder=${PWD##*/}; cp -r "${PWD}/dist/" "../dist/${working_folder}"'


### PR DESCRIPTION
## Purpose

Exclude `common` from  dist creation in the workflow. 

### Open Questions and Pre-Merge TODOs

Please ensure your pull request adheres to the following guidelines:

- [x] There are tests that cover at least 75% of the step extension code
- [x] All tests pass with `yarn test`
- [x] Improvements of existing step extensions should be backwards compatible unless specified otherwise.
- [x] There is a corresponding view definition in the catalog https://github.com/KaotoIO/kaoto-viewdefinition-catalog
