### PR TITLE
fix: when multiple operations, more than one endpoint was generated

### DIFF
--- a/rest-dsl/src/Components/RestStep.tsx
+++ b/rest-dsl/src/Components/RestStep.tsx
@@ -56,6 +56,8 @@ async function parseApiSpec(
             let consumes: Map<string, string[]> = new Map<string, string[]>();
             let produce: Map<string, string> = new Map<string, string>();
             let consume: Map<string, string> = new Map<string, string>();
+            let operation: Map<string, OpenAPI.Operation> = new Map<string, OpenAPI.Operation>();
+            operation.set(verb, op);
             const producesMediaType: string[] = [];
             if ('produces' in op) {
               op.produces?.forEach((prod: string) => producesMediaType.push(prod));
@@ -79,7 +81,7 @@ async function parseApiSpec(
               }
             }
             // @ts-expect-error | The problem comes from `verb` not being recognized as a HttpMethods from OpenAPIV2, OpenAPIV3, OpenAPIV3_1
-            e.push({ name: key, path: path[verb].operationId, operations, produces, consumes, produce, consume });
+            e.push({ name: key, path: path[verb].operationId, operations: operation, produces, consumes, produce, consume });
           });
         }
       });


### PR DESCRIPTION
Fixing a bug on the REST DSL that duplicated endpoints when there was more than one verb on the same path.

#### How to reproduce
1. Using `https://petstore3.swagger.io/api/v3/openapi.json`
    ![image](https://github.com/KaotoIO/step-extension-repository/assets/16512618/5e0ab7c2-0e54-469f-9f1f-92884025bcb1)

2. The extension states that 19 endpoints are gonna be created
    ![image](https://github.com/KaotoIO/step-extension-repository/assets/16512618/e6f28496-7152-4fad-82db-4bf2e840fcb8)

3. After clicking `Generate`, now the button state that 35 endpoints are going to be generated and some endpoints are duplicated
    ![image](https://github.com/KaotoIO/step-extension-repository/assets/16512618/4419e2b2-205d-46b5-842d-445d032238bc)

#### Expected result
1. No duplicated endpoints and the button still states that `19 endpoints` will be created.
![image](https://github.com/KaotoIO/step-extension-repository/assets/16512618/b463ffbf-b38f-4859-ab1a-d55c2e3c078f)
