### PR TITLE
fix(rest-dsl): Cannot parse Apicurio OpenApi

### DIFF
--- a/rest-dsl/src/Components/__snapshots__/parse-api.test.ts.snap
+++ b/rest-dsl/src/Components/__snapshots__/parse-api.test.ts.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseApiSpec should parse an OpenAPI spec 1`] = `
+[
+  {
+    "consume": Map {},
+    "consumes": Map {},
+    "name": "/token",
+    "operations": Map {
+      "post" => {
+        "operationId": "mock1",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "string",
+              },
+            },
+          },
+          "description": "Mock request body",
+          "required": true,
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "examples": {
+                  "token example": {
+                    "value": {
+                      "access_token": "4e188f51-6ff4-3eb0-bb8b-235b652b123a",
+                      "expires_in": 3600,
+                      "token_type": "Bearer",
+                    },
+                  },
+                },
+              },
+            },
+            "description": "returns specific token",
+          },
+        },
+        "summary": "mock of the token endpoint",
+      },
+    },
+    "path": "mock1",
+    "produce": Map {},
+    "produces": Map {
+      "post" => [
+        "application/json",
+      ],
+    },
+  },
+  {
+    "consume": Map {},
+    "consumes": Map {},
+    "name": "/status",
+    "operations": Map {
+      "get" => {
+        "operationId": "getstatus",
+        "responses": {
+          "200": {
+            "description": "Get status",
+          },
+        },
+      },
+    },
+    "path": "getstatus",
+    "produce": Map {},
+    "produces": Map {
+      "get" => [],
+    },
+  },
+]
+`;

--- a/rest-dsl/src/Components/parse-api.test.ts
+++ b/rest-dsl/src/Components/parse-api.test.ts
@@ -1,0 +1,15 @@
+import { parseApiSpec } from './parse-api';
+import { readFile } from 'fs/promises';
+import { resolve } from 'path';
+import { parse } from 'yaml';
+
+describe('parseApiSpec', () => {
+  it('should parse an OpenAPI spec', async () => {
+    const filename = resolve('src/Components/test/open-api_wso-mock.yaml');
+    const openApiSpec = await readFile(filename, { encoding: 'utf8' });
+
+    const spec = await parseApiSpec(parse(openApiSpec));
+
+    expect(spec).toMatchSnapshot();
+  });
+});

--- a/rest-dsl/src/Components/parse-api.ts
+++ b/rest-dsl/src/Components/parse-api.ts
@@ -1,0 +1,71 @@
+import { OpenAPI } from 'openapi-types';
+import { IEndpoint } from './RestStep';
+import SwaggerParser from '@apidevtools/swagger-parser';
+
+export async function parseApiSpec(
+  input: string | OpenAPI.Document
+): Promise<IEndpoint[]> {
+  let swaggerParser: SwaggerParser = new SwaggerParser();
+
+  const e: Array<IEndpoint> = [];
+  try {
+    await swaggerParser.validate(input, { dereference: { circular: 'ignore' } });
+    const paths = swaggerParser.api.paths;
+    if (paths) {
+      Object.keys(paths).forEach((key: string) => {
+        const path = paths[key];
+        if (path) {
+          const operations: Map<string, OpenAPI.Operation> = new Map<string, OpenAPI.Operation>();
+
+          Object.entries(path).forEach((method: [string, OpenAPI.Operation]) => {
+            operations.set(method[0], method[1]);
+          });
+
+          operations.forEach((op: OpenAPI.Operation, verb: string) => {
+            let produces: Map<string, string[]> = new Map<string, string[]>();
+            let consumes: Map<string, string[]> = new Map<string, string[]>();
+            let produce: Map<string, string> = new Map<string, string>();
+            let consume: Map<string, string> = new Map<string, string>();
+            let operation: Map<string, OpenAPI.Operation> = new Map<string, OpenAPI.Operation>();
+            operation.set(verb, op);
+            const producesMediaType: string[] = [];
+
+            if (typeof op !== 'object') {
+              return;
+            }
+
+            if ('produces' in op) {
+              op.produces?.forEach((prod: string) => producesMediaType.push(prod));
+              if (producesMediaType.length > 0) {
+                produce.set(verb, producesMediaType[0]);
+              }
+            } else if (op.responses) {
+              Object.values(op.responses).forEach((response) => {
+                if (response.content) {
+                  producesMediaType.push.apply(producesMediaType, (Object.keys(response.content)));
+                }
+              });
+            }
+
+            produces.set(verb, producesMediaType);
+
+            if ('consumes' in op) {
+              const consumesMediaTypes: string[] = [];
+              consumes.set(verb, consumesMediaTypes);
+              op.consumes?.forEach((con: string) => consumesMediaTypes.push(con));
+              if (consumesMediaTypes.length > 0) {
+                consume.set(verb, consumesMediaTypes[0]);
+              }
+            }
+
+            // @ts-expect-error | The problem comes from `verb` not being recognized as a HttpMethods from OpenAPIV2, OpenAPIV3, OpenAPIV3_1
+            e.push({ name: key, path: path[verb].operationId, operations: operation, produces, consumes, produce, consume });
+          });
+        }
+      });
+    }
+  } catch (error) {
+    console.error(error);
+  }
+  return e;
+}

--- a/rest-dsl/src/Components/test/open-api_wso-mock.yaml
+++ b/rest-dsl/src/Components/test/open-api_wso-mock.yaml
@@ -1,0 +1,54 @@
+---
+openapi: 3.0.2
+info:
+  title: wso-mock
+  version: 1.0.0
+  description: Mocking the WSO2 response
+  contact:
+    name: developer
+    url: http://www.redhat.com
+    email: sgutierr@redhat.com
+  license:
+    name: GNU GPLv3
+    url: https://www.gnu.org/licenses/gpl.txt
+paths:
+  /token:
+    summary: getToken
+    post:
+      requestBody:
+        description: Mock request body
+        content:
+          application/json:
+            schema:
+              type: string
+        required: true
+      responses:
+        "200":
+          content:
+            application/json:
+              examples:
+                token example:
+                  value:
+                    access_token: 4e188f51-6ff4-3eb0-bb8b-235b652b123a
+                    token_type: Bearer
+                    expires_in: 3600
+          description: returns specific token
+      operationId: mock1
+      summary: mock of the token endpoint
+  /status:
+    get:
+      responses:
+        "200":
+          description: Get status
+      operationId: getstatus
+components:
+  schemas:
+    reponseToken:
+      description: responseToken
+      type: object
+      properties:
+        body:
+          description: body
+tags:
+- name: mock
+  description: mocking endpoint


### PR DESCRIPTION
### Context
Currently, the `summary` field from Apicurio-generated OpenApi cannot be parsed.

### Changes
This commit adds a check to determine whether the operation is an object or a string before trying to parse it.

fixes: https://github.com/KaotoIO/kaoto-ui/issues/2279
